### PR TITLE
fix(docs): replace special chars in conventions guide

### DIFF
--- a/src/Resources/doc/guides/conventions.rst
+++ b/src/Resources/doc/guides/conventions.rst
@@ -9,15 +9,15 @@ existing file inside the ``Data`` directory. The ``name`` also needs to match th
 .. code-block:: text
 
     Acme/
-    └─ HelloBundle/
-       └─ DataFixtures/
-          └─ ORM/
-             ├─ Data/
-             ├─ ├─ User.yml
-             ├─ └─ ...
-             ├─ AcmeHelloOrmFixture.php
-             ├─ LoadUserData.php
-             └─ ...
+    `-- HelloBundle/
+        `-- DataFixtures/
+            `-- ORM/
+                |-- Data/
+                |   |-- User.yml
+                |   `-- (other data files)
+                |-- AcmeHelloOrmFixture.php
+                |-- LoadUserData.php
+                `-- (other fixture classes)
 
 The names of the entity fields inside the YAML file also need to follow a convention,
 as the the bundle uses it to infer the setter method to call in order to set their value:


### PR DESCRIPTION
Should fix all the errors like:
`! Package inputenc Error: Unicode char \u8:├ not set up for use with LaTeX.`
