### PR TITLE
chore(coverage-report): move report location back inside the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .*
 composer.lock
+artifacts/
 bin/
 build/
 vendor/

--- a/phpspec.yml
+++ b/phpspec.yml
@@ -8,5 +8,5 @@ code_coverage:
     - html
     - clover
   output:
-    html: ../artifacts/coverage
+    html: artifacts/coverage
     clover: build/logs/clover.xml


### PR DESCRIPTION
Scrutinizer does not save artifacts for public repositories, so there is no point in saving the coverage report in the previous location.
